### PR TITLE
Calculate total progress in repo, refactor regexes to removeprefix & …

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Polskie tłumaczenie dokumentacji Pythona
 ========================================
 ![build](https://github.com/python/python-docs-pl/workflows/.github/workflows/update-and-build.yml/badge.svg)
 ![48.35% przełącznika języków](https://img.shields.io/badge/przełącznik_języków-48.35%25-0.svg)
-![postęp tłumaczenia całości dokumentacji](https://img.shields.io/badge/dynamic/json.svg?label=całość&query=$.pl&url=http://gce.zhsj.me/python/newest)
+![postęp tłumaczenia całości dokumentacji](https://img.shields.io/badge/całość-3.51%25-0.svg)
 ![19 tłumaczy](https://img.shields.io/badge/tłumaczy-19-0.svg)
 
 Jeśli znalazłeś(-aś) błąd lub masz sugestię,

--- a/manage_translation.py
+++ b/manage_translation.py
@@ -161,7 +161,7 @@ def _get_resource_language_stats() -> list[ResourceLanguageStatistics]:
     return [ResourceLanguageStatistics.from_api_v3_entry(entry) for entry in resources]
 
 
-LANGUAGE_SWITCHER_RESOURCES_PREFIXES = ('bugs', 'tutorial', 'library--functions')  # is compatible with 3.10?
+LANGUAGE_SWITCHER_RESOURCES_PREFIXES = ('bugs', 'tutorial', 'library--functions')
 
 
 def recreate_readme():

--- a/manage_translation.py
+++ b/manage_translation.py
@@ -16,11 +16,11 @@ from argparse import ArgumentParser
 from collections import Counter
 import os
 from dataclasses import dataclass
-from re import match, search
+from re import match
 from subprocess import call, run
 import sys
-from typing import Self
-from urllib.parse import unquote
+from typing import Self, Callable
+from urllib.parse import urlparse, parse_qs
 
 LANGUAGE = 'pl'
 
@@ -112,7 +112,7 @@ class ResourceLanguageStatistics:
     @classmethod
     def from_api_v3_entry(cls, data: dict) -> Self:
         return cls(
-            name=search('r:([^:]*)', data['id']).group(1),
+            name=data['id'].removeprefix(f'o:python-doc:p:{PROJECT_SLUG}:r:').removesuffix(f':l:{LANGUAGE}'),
             total_words=data['attributes']['total_words'],
             translated_words=data['attributes']['translated_words'],
             total_strings=data['attributes']['total_strings'],
@@ -129,7 +129,7 @@ def _get_from_api_v3_with_cursor(url: str, params: dict):
         with open('.tx/api-key') as f:
             transifex_api_key = f.read()
     else:
-        transifex_api_key = os.getenv('TX_TOKEN')
+        transifex_api_key = os.getenv('TX_TOKEN', '')
     while True:
         response = get(
             url,
@@ -142,7 +142,7 @@ def _get_from_api_v3_with_cursor(url: str, params: dict):
         resources.extend(response_list)
         if not response_json['links'].get('next'):  # for stats no key, for list resources null
             break
-        cursor = unquote(search('page\[cursor]=([^&]*)', response_json['links']['next']).group(1))
+        cursor, *_ = parse_qs(urlparse(response_json['links']['next']).query)['page[cursor]']
     return resources
 
 
@@ -180,15 +180,10 @@ def recreate_readme():
             or entry.name.startswith('library--functions')
         )
 
-    def average(averages, weights):
-        return sum([a * w for a, w in zip(averages, weights)]) / sum(weights)
 
     resources = _get_resource_language_stats()
-    filtered = list(filter(language_switcher, resources))
-    average_list = [e.translated_words / e.total_words for e in filtered]
-    weights_list = [e.total_words for e in filtered]
-
-    language_switcher_status = average(average_list, weights=weights_list) * 100
+    language_switcher_status = progress_from_resources(resources, language_switcher)
+    total_progress_status = progress_from_resources(resources, lambda _: True)
     number_of_translators = _get_number_of_translators()
 
     with open('README.md', 'w') as file:
@@ -198,7 +193,7 @@ Polskie tłumaczenie dokumentacji Pythona
 ========================================
 ![build](https://github.com/python/python-docs-pl/workflows/.github/workflows/update-and-build.yml/badge.svg)
 ![{language_switcher_status:.2f}% przełącznika języków](https://img.shields.io/badge/przełącznik_języków-{language_switcher_status:.2f}%25-0.svg)
-![postęp tłumaczenia całości dokumentacji](https://img.shields.io/badge/dynamic/json.svg?label=całość&query=$.{LANGUAGE}&url=http://gce.zhsj.me/python/newest)
+![postęp tłumaczenia całości dokumentacji](https://img.shields.io/badge/całość-{total_progress_status:.2f}%25-0.svg)
 ![{number_of_translators} tłumaczy](https://img.shields.io/badge/tłumaczy-{number_of_translators}-0.svg)
 
 Jeśli znalazłeś(-aś) błąd lub masz sugestię,
@@ -253,6 +248,16 @@ Wyrażasz akceptację tej umowy przesyłając swoją pracę do włączenia do do
 * [polskie tłumaczenie dokumentacji Pythona 2.3](https://pl.python.org/docs/).
 '''
         )
+
+
+def progress_from_resources(resources: list, filter_function: Callable):
+    def _average(averages, weights):
+        return sum([a * w for a, w in zip(averages, weights)]) / sum(weights)
+
+    filtered = list(filter(filter_function, resources))
+    average_list = [e.translated_words / e.total_words for e in filtered]
+    weights_list = [e.total_words for e in filtered]
+    return _average(average_list, weights=weights_list) * 100
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…removesuffix or parsing URL and querystring, return default API key as empty string for types check passing

After sunset of Transifex API v2, badge we used stopped working (see https://github.com/zhsj/tx-badge/issues/1). This changes switch to local calculations, similar as we already did for language switcher.

I also did refactor to switch from regexes to remove-prefix/suffix and URL/querystring parsing.

Tested locally, on Python 3.10.