### PR TITLE
Create license.md to replace license.po being displayed

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,0 +1,4 @@
+**License**
+
+By inviting you to work on a project on the Transifex platform, we offer a contract for donating your translations to the Python Software Foundation under the CC0 license. 
+In return, it will be visible that you are the translator of the part you translated. You signify your acceptance of this agreement by submitting your work for inclusion in the documentation.


### PR DESCRIPTION
Currently the contents of `license.po` are being displayed as the License so it should probably be updated to the proper license. 