### PR TITLE
Add fail-fast: false to workflows

### DIFF
--- a/.github/workflows/update-lint-and-build.yml
+++ b/.github/workflows/update-lint-and-build.yml
@@ -12,6 +12,7 @@ jobs:
   update-translation:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: [3.13, 3.12, 3.11, '3.10', 3.9]
     steps:
@@ -61,6 +62,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: [3.13, 3.12, 3.11]
     needs: ['update-translation']
@@ -78,6 +80,7 @@ jobs:
   build-translation:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: [3.13, 3.12, 3.11, '3.10', 3.9, 3.8]
         format: [html, latex]


### PR DESCRIPTION
Suggested by @rffontenelle . Now all actions for the matrix will not be canceled after a single fail in one. (More red, yay! ;-)

Doc: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast