### PR TITLE
Update view count link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Wyrażasz akceptację tej umowy przesyłając swoją pracę do włączenia do do
 * `cog -rP README.md`
 
 **Przydatne materiały**
-* [statystyki oglądalności](https://plausible.io/docs.python.org/?filters=%28%28contains,page,%28/pl/%29%29%29)
+* [statystyki oglądalności](https://analytics.python.org/docs.python.org?f=contains,page,/pl/)
 * [Python Developer's Guide: Documentation](https://devguide.python.org/documentation/)
 
 **Podobne projekty**


### PR DESCRIPTION
As Python switched to self-hosted analytics, the address for statistics has changed.