### PR TITLE
Don't treat project name change as significant to commit

### DIFF
--- a/.github/workflows/update-lint-and-build.yml
+++ b/.github/workflows/update-lint-and-build.yml
@@ -54,7 +54,7 @@ jobs:
       - run: git config --local user.name "GitHub Action's update-translation job"
       - name: Check changes significance
         run: >
-          ! git diff -I'^"POT-Creation-Date: ' -I'^"Language-Team: ' -I'^# ' -I'^"Last-Translator: ' --exit-code && echo "SIGNIFICANT_CHANGES=1" >> $GITHUB_ENV || exit 0
+          ! git diff -I'^"POT-Creation-Date: ' -I'^"Language-Team: ' -I'^# ' -I'^"Last-Translator: ' -I'^"Project-Id-Version: ' --exit-code && echo "SIGNIFICANT_CHANGES=1" >> $GITHUB_ENV || exit 0
       - run: git add .
       - run: git commit -m 'Update translation from Transifex'
         if: env.SIGNIFICANT_CHANGES


### PR DESCRIPTION
Prevent commits like this https://github.com/python/python-docs-pl/commit/98118f6f0406e61eeb3d1863efa5e0ac426c95cd, where only project name changes.