### PR TITLE
Remove unneeded deps

### DIFF
--- a/.github/workflows/update-lint-and-build.yml
+++ b/.github/workflows/update-lint-and-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y gettext
-          pip install requests cogapp polib transifex-python sphinx-intl
+          pip install requests cogapp polib transifex-python sphinx-intl six
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
         working-directory: /usr/local/bin
       - uses: actions/checkout@master

--- a/.github/workflows/update-lint-and-build.yml
+++ b/.github/workflows/update-lint-and-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y gettext
-          pip install requests cogapp polib transifex-python sphinx-intl blurb six
+          pip install requests cogapp polib transifex-python sphinx-intl
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
         working-directory: /usr/local/bin
       - uses: actions/checkout@master


### PR DESCRIPTION
I'm not sure where the need for them came from. Python 2.7 is long gone, and why blurb ever be needed...? I'm pretty sure we can remove `requests` and `sphinx-intl` too.