### PR TITLE
Stop `license.po` from appearing as a license

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+license.po linguist-generated


### PR DESCRIPTION
Per https://github.com/orgs/community/discussions/152708

Should stop:

<img width="1659" height="491" alt="image" src="https://github.com/user-attachments/assets/a37d4a0b-e03a-4016-8796-b22e38a6ae2c" />
