### PR TITLE
Temporarily exclude versions with bad translation propagations from workflows

### DIFF
--- a/.github/workflows/update-lint-and-build.yml
+++ b/.github/workflows/update-lint-and-build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.14, 3.13, 3.12, 3.11, '3.10', 3.9]
+        version: [3.14, 3.13, 3.12, 3.9]
     steps:
       - uses: styfle/cancel-workflow-action@main
         with:
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.14, 3.13, 3.12, 3.11]
+        version: [3.14, 3.13, 3.12]
     needs: ['update']
     continue-on-error: true
     steps:
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.14, 3.13, 3.12, 3.11, '3.10', 3.9]
+        version: [3.14, 3.13, 3.12, 3.9]
         format: [html, latex, epub]
     needs: ['update']
     steps:
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.14, 3.13, 3.12, 3.11, '3.10', 3.9]
+        version: [3.14, 3.13, 3.12, 3.9]
     needs: ['build']
     steps:
       - uses: actions/download-artifact@master


### PR DESCRIPTION
According to [current fix state](https://github.com/python-docs-translations/transifex-automations/issues/155#issuecomment-3276908735). This will allow us to run further workflow steps (lint & build) for already fixed versions – for now through manual dispatch and on pushes.