### PR TITLE
Stop pulling 3.9

### DIFF
--- a/.github/ISSUE_TEMPLATE/typo.yml
+++ b/.github/ISSUE_TEMPLATE/typo.yml
@@ -26,7 +26,6 @@ body:
       label: "Wersja dokumentacji:"
       multiple: true
       options:
-        - "3.9"
         - "3.10"
         - "3.11"
         - "3.12"

--- a/.github/workflows/update-lint-and-build.yml
+++ b/.github/workflows/update-lint-and-build.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.14, 3.13, 3.12, 3.11, '3.10', 3.9]
+        version: [3.14, 3.13, 3.12, 3.11, '3.10']
         format: [html, latex, epub]
     needs: ['update']
     steps:
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.14, 3.13, 3.12, 3.11, '3.10', 3.9]
+        version: [3.14, 3.13, 3.12, 3.11, '3.10']
     needs: ['build']
     steps:
       - uses: actions/download-artifact@master

--- a/.github/workflows/update-lint-and-build.yml
+++ b/.github/workflows/update-lint-and-build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.14, 3.13, 3.12, 3.11, '3.10', 3.9]
+        version: [3.14, 3.13, 3.12, 3.11, '3.10']
     steps:
       - uses: styfle/cancel-workflow-action@main
         with:


### PR DESCRIPTION
To be merged when it is archive (see https://github.com/python-docs-translations/transifex-automations/issues/196).