### PR TITLE
[3.12] Create virtual environment for gettext build when updating tx config

### DIFF
--- a/manage_translation.py
+++ b/manage_translation.py
@@ -90,6 +90,7 @@ def _clone_cpython_repo(version: str):
 
 
 def _build_gettext():
+    _call("make -C cpython/Doc/ venv")
     _call("make -C cpython/Doc/ gettext")
 
 


### PR DESCRIPTION
Sphinx 9 is not compatible with CPython 3.12 branch docs, we should utilize version of Sphinx pinned along Python version docs.