### PR TITLE
Add friendly-traceback to similar projects

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -90,3 +90,4 @@ You signify your acceptance of this agreement by submitting your work for inclus
 * [micro:bit translation programme](https://microbit.org/translate/)
 * [Sphinx translation](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html#contributing-to-sphinx-reference-translation)
 * [Localizing Django](https://docs.djangoproject.com/en/dev/internals/contributing/localizing/)
+* [friendly-traceback: notes on translations](https://friendly-traceback.github.io/docs/translation_notes.html)

--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ Wyrażasz akceptację tej umowy przesyłając swoją pracę do włączenia do do
 * [micro:bit translation programme](https://microbit.org/translate/)
 * [tłumaczenie Sphinksa](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html#contributing-to-sphinx-reference-translation)
 * [Localizing Django](https://docs.djangoproject.com/en/dev/internals/contributing/localizing/)
+* [friendly-traceback: notes on translations](https://friendly-traceback.github.io/docs/translation_notes.html)


### PR DESCRIPTION
`friendly-traceback` contains Python-related localisation. It's a utility that lowers the entrypoint barrier to Python, it's used in education.